### PR TITLE
[fix] Install cURL package

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,15 @@
     state: latest
   tags: [influxdb]
 
+- name: Install system dependencies
+  apt:
+    name:
+      - curl
+      - rsyslog
+    cache_valid_time: 3000
+    state: latest
+  tags: [influxdb]
+
 - name: Add influxdb key
   apt_key:
     url: https://repos.influxdata.com/influxdb.key


### PR DESCRIPTION
ansible-openwisp2 build was failing due to absence of cURL package
which is used in influxdb start script.