### PR TITLE
[change] Improved creating and updating user #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,12 @@ Role Variables
 # By default query logging of InfluxDB is turned off since it can occupy a
 # lot of storage. You can turn it on by setting below variable to true.
 influxdb_query_logging: true
+# The username of the influxdb user that will be created.
+influxdb_user_username: admin
+# The password of the influxdb user that will be created.
+influxdb_user_password: "your-strong-password"
+# The hostname or IP address on which InfluxDB server is listening.
+influxdb_http_ip: "localhost"
+# The port on which InfluxDB server is listening.
+influxdb_http_port: 8086
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,6 @@
 influxdb_http_ip: "localhost"
 influxdb_http_port: 8086
 influxdb_query_logging: false
+influxdb_user_username: admin
+# For backward compatibility
+influxdb_user_password: "{{ inflxudb_admin_password | default(None) }}"

--- a/tasks/authentication.yml
+++ b/tasks/authentication.yml
@@ -1,0 +1,51 @@
+# Disabling authentication is also required for updating user password
+- name: Disable influxdb authentication
+  lineinfile:
+    path: "/etc/influxdb/influxdb.conf"
+    line: "  auth-enabled = true"
+    insertafter: |
+      "  # Determines whether user authentication is enabled over HTTP/HTTPS."
+    state: absent
+  register: disable_influxdb_auth
+  changed_when: not influxdb_user_password
+  notify: restart influxdb
+
+- name: Restart influxdb
+  service:
+    name: influxdb
+    state: restarted
+  when: influxdb_user_password
+  changed_when: false
+
+- name: Wait for influxdb to restart
+  pause: seconds=3
+  when: influxdb_user_password
+
+- name: Create influxdb user
+  shell:
+    cmd: |
+      echo "CREATE USER {{ influxdb_user_username }} WITH password '{{ influxdb_user_password }}' WITH ALL PRIVILEGES;" \
+          | influx -host {{ influxdb_http_ip }} \
+          && touch /etc/influxdb/.admin_created
+    creates: /etc/influxdb/.admin_created
+  when: influxdb_user_password
+  notify: restart influxdb
+
+- name: Update user password
+  shell:
+    cmd: |
+      echo "SET PASSWORD FOR {{ influxdb_user_username }} = '{{ influxdb_user_password }}'" \
+        | influx -host {{ influxdb_http_ip }}
+  when: influxdb_user_password
+  notify: restart influxdb
+
+- name: Enable influxdb authentication
+  lineinfile:
+    path: "/etc/influxdb/influxdb.conf"
+    line: "  auth-enabled = true"
+    insertafter: "  # Determines whether user authentication is enabled over HTTP/HTTPS."
+    state: present
+  when: influxdb_user_password
+  register: enable_influxdb_auth
+  changed_when: |
+    "changed" in enable_influxdb_auth and "changed" not in disable_influxdb_auth

--- a/tasks/authentication.yml
+++ b/tasks/authentication.yml
@@ -37,6 +37,7 @@
       echo "SET PASSWORD FOR {{ influxdb_user_username }} = '{{ influxdb_user_password }}'" \
         | influx -host {{ influxdb_http_ip }}
   when: influxdb_user_password
+  changed_when: false
   notify: restart influxdb
 
 - name: Enable influxdb authentication

--- a/tasks/authentication.yml
+++ b/tasks/authentication.yml
@@ -1,4 +1,4 @@
-# Disabling authentication is also required for updating user password
+# Disabling authentication is required for updating user password
 - name: Disable influxdb authentication
   lineinfile:
     path: "/etc/influxdb/influxdb.conf"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -119,22 +119,5 @@
     enabled: yes
   tags: [influxdb]
 
-- name: Ensure influxdb admin user is present
-  shell:
-    cmd: |
-      echo "CREATE USER admin WITH password '{{ inflxudb_admin_password }}' WITH ALL PRIVILEGES;" \
-           | influx -host {{ influxdb_http_ip }} \
-           && touch /etc/influxdb/.admin_created
-    creates: /etc/influxdb/.admin_created
-  when: inflxudb_admin_password is defined
-  register: influxdb_admin_created
+- import_tasks: authentication.yml
   tags: [influxdb]
-
-- name: Enable authentication
-  lineinfile:
-    path: "/etc/influxdb/influxdb.conf"
-    line: "  auth-enabled = true"
-    insertafter: "  # Determines whether user authentication is enabled over HTTP/HTTPS."
-  when: inflxudb_admin_password is defined
-  tags: [influxdb]
-  notify: restart influxdb


### PR DESCRIPTION
InfluxDB authentication will be enabled only when
influxdb_user_password is defined in the playbook.

- Allowed updating InfluxDB user's password
- Made InfluxDB user's username configurable:
    influxdb_user_username (defaults to "admin")
- Added documentation for role variables

Closes #5