### PR TITLE
InfluxData repo change

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,7 +38,7 @@
 
 - name: Add influxdb repo
   apt_repository:
-    repo: "deb https://repos.influxdata.com/{{ ansible_distribution.lower() }}/ {{ ansible_distribution_release  }} stable"
+    repo: "deb https://repos.influxdata.com/{{ ansible_distribution.lower() }} stable main"
     state: present
   tags: [influxdb]
 


### PR DESCRIPTION
The policy of InfluxData changed in the way that they want to offer the repos for apt based systems at least.
Instead of `$releasever stable` they only want to offer from now on a `stable main` repo for all versions of Debian or  Ubuntu.

This is needed to support Debian Bookworm at least.