### PR TITLE
[chores] Pinned InfluxDB to 1.11.7-1

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,7 @@
   apt:
     name:
       - rsyslog
+      - curl
     cache_valid_time: 3000
     state: latest
   tags: [influxdb]


### PR DESCRIPTION
InfluxDB=1.11.8-1 contains a bug in the pre-install script. For more info, check https://github.com/influxdata/influxdb/issues/25571