### PR TITLE
[feature] Added settings to configure data dir of InfluxDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,4 +81,7 @@ influxdb_udp_settings: |
   bind-address = "{{ influxdb_http_ip }}:8090"
   database = "openwisp2"
   retention-policy = "short"
+# When "influxdb_data_dir" is set to a path different from the default
+# (/var/lib/influxdb), InfluxDB will store its data in the specified directory.
+influxdb_data_dir: "/opt/influxdb"
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ influxdb_http_port: 8086
 influxdb_query_logging: false
 influxdb_user_username: admin
 influxdb_index_version: inmem
+influxdb_data_dir: /var/lib/influxdb
 influxdb_udp_mode: false
 influxdb_udp_settings: |
   # For writing data with the "default" retention policy

--- a/molecule/resources/verify.yml
+++ b/molecule/resources/verify.yml
@@ -33,3 +33,35 @@
           failed_when: '"results" not in db_created_response.stdout'
           changed_when: false
       when: influxdb_user_password is not defined or not influxdb_user_password | bool
+
+    - name: Test influxdb data directory configuration
+      block:
+        - name: Read InfluxDB configuration file
+          slurp:
+            src: /etc/influxdb/influxdb.conf
+          register: influxdb_config_content
+
+        - name: Test default data directory when variable not changed
+          block:
+            - name: Read InfluxDB configuration file
+              slurp:
+                src: /etc/influxdb/influxdb.conf
+              register: influxdb_config_content
+
+            - name: Verify default data directory is present
+              assert:
+                that:
+                  - "'/var/lib/influxdb' in (influxdb_config_content.content | b64decode)"
+                fail_msg: "InfluxDB should use default /var/lib/influxdb when influxdb_data_dir is not defined or unchanged"
+                success_msg: "InfluxDB correctly using default data directory /var/lib/influxdb"
+          when: influxdb_data_dir is not defined or influxdb_data_dir == '/var/lib/influxdb'
+
+        - name: Verify data directory has been updated in configuration
+          assert:
+            that:
+              - influxdb_data_dir is defined
+              - "'/var/lib/influxdb' not in (influxdb_config_content.content | b64decode)"
+              - "influxdb_data_dir in (influxdb_config_content.content | b64decode)"
+            fail_msg: "InfluxDB configuration should use {{ influxdb_data_dir | default('/var/lib/influxdb') }} instead of default /var/lib/influxdb"
+            success_msg: "InfluxDB data directory correctly configured as {{ influxdb_data_dir | default('/var/lib/influxdb') }}"
+          when: influxdb_data_dir is defined and influxdb_data_dir != '/var/lib/influxdb'

--- a/tasks/data_dir.yml
+++ b/tasks/data_dir.yml
@@ -1,0 +1,56 @@
+---
+- name: Stop influxdb service
+  service:
+    name: influxdb
+    state: stopped
+  tags: [ influxdb ]
+
+- name: Create influxdb data directory if it does not exist
+  file:
+    path: "{{ influxdb_data_dir }}"
+    state: directory
+    owner: influxdb
+    group: influxdb
+  tags: [ influxdb ]
+
+- name: Update influxdb meta directory
+  ansible.builtin.lineinfile:
+    path: /etc/influxdb/influxdb.conf
+    regexp: '^\s*dir\s*=\s*".*/meta"'
+    line: '  dir = "{{ influxdb_data_dir }}/meta"'
+    insertafter: '\[meta\]'
+  notify: restart influxdb
+  tags: [ influxdb ]
+
+- name: Update influxdb data directory
+  ansible.builtin.lineinfile:
+    path: /etc/influxdb/influxdb.conf
+    regexp: '^\s*dir\s*=\s*".*/data"'
+    line: '  dir = "{{ influxdb_data_dir }}/data"'
+    insertafter: '\[data\]'
+  notify: restart influxdb
+  tags: [ influxdb ]
+
+- name: Update influxdb wal directory
+  ansible.builtin.lineinfile:
+    path: /etc/influxdb/influxdb.conf
+    regexp: '^\s*wal-dir\s*=\s*".*/wal"'
+    line: '  wal-dir = "{{ influxdb_data_dir }}/wal"'
+    insertafter: '\[data\]'
+  notify: restart influxdb
+  tags: [ influxdb ]
+
+- name: Start influxdb service
+  service:
+    name: influxdb
+    state: started
+  tags: [ influxdb ]
+
+- name: Set influxdb dir permissions
+  file:
+    path: "{{ influxdb_data_dir }}"
+    state: directory
+    owner: influxdb
+    group: influxdb
+    recurse: true
+  tags: [ influxdb ]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -140,6 +140,10 @@
     enabled: true
   tags: [influxdb]
 
+- import_tasks: data_dir.yml
+  when: influxdb_data_dir is defined and influxdb_data_dir != '/var/lib/influxdb'
+  tags: [influxdb]
+
 - import_tasks: authentication.yml
   tags: [influxdb]
 


### PR DESCRIPTION
I reopened https://github.com/openwisp/ansible-ow-influxdb/pull/31 here because it get close automatically when I tried to rebase.

```
# When "influxdb_data_dir" is set to a path different from the default
# (/var/lib/influxdb), InfluxDB will store its data in the specified directory.
influxdb_data_dir: "/opt/influxdb"
```