### PR TITLE
[fix] Update InfluxData key path

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,6 @@
   shell: gpg --dearmor < /tmp/influxdata-key-ascii > /usr/share/keyrings/influxdata-archive.gpg
   args:
     creates: /usr/share/keyrings/influxdata-archive.gpg
-  when: not influxdb_binary_key.stat.exists
   tags: [influxdb]
 
 - name: Add InfluxData repository


### PR DESCRIPTION
It seems apt has evolved and now using on all debian and ubuntu versions.
Here is why:

/usr/share/keyrings/: This is the current best practice. It allows you to use the signed-by option in your repository definition. This isolates the key so it is only trusted for that specific repository, rather than being trusted globally by apt for all packages.

/etc/apt/trusted.gpg.d/: This is considered legacy/deprecated for third-party repositories. Any key placed here is trusted for any repository on the system, which is a slight security risk (a compromised third-party repo could theoretically sign a replacement for a core system package).